### PR TITLE
dpkg/control: migrate to fuse3

### DIFF
--- a/dpkg/control
+++ b/dpkg/control
@@ -1,7 +1,7 @@
 Source: libolecf
 Priority: extra
 Maintainer: Joachim Metz <joachim.metz@gmail.com>
-Build-Depends: debhelper (>= 9), dh-autoreconf, dh-python, pkg-config, python3-dev, python3-setuptools, libfuse-dev
+Build-Depends: debhelper (>= 9), dh-autoreconf, dh-python, pkg-config, python3-dev, python3-setuptools, libfuse3-dev
 Standards-Version: 4.1.4
 Section: libs
 Homepage: https://github.com/libyal/libolecf


### PR DESCRIPTION
fuse 2.x is obsolete, see https://bugs.debian.org/1084436, while libolecf seems to support fuse3 already, so adapt the build dependency accordingly for switching to fuse3.

Not sure how relevant the `dpkg` files are actually, but as I was working on the Debian package for/in Debian itself (also see https://salsa.debian.org/pkg-security-team/libolecf/-/merge_requests/3), I wanted to make sure you're also aware of it. :)